### PR TITLE
Fix experience eating for scaling bingos

### DIFF
--- a/src/main/java/xyz/iwolfking/scalingbingoseals/mixin/MixinApplySealRecipe.java
+++ b/src/main/java/xyz/iwolfking/scalingbingoseals/mixin/MixinApplySealRecipe.java
@@ -22,6 +22,7 @@ public class MixinApplySealRecipe {
         CrystalData outputData = CrystalData.read(output);
         if(outputData.getObjective() instanceof ScalingBingoCrystalObjective scalingBingoCrystalObjective) {
             context.setName(scalingBingoCrystalObjective.getCrystalName());
+            context.setLevelCost(-1);
         }
     }
 }


### PR DESCRIPTION
In minecraft renaming item adds +1 level requirement for all anvil operations.

As workbench uses anvil recipe simulator to display outcome per tick, the option to set name just eats all player levels the longer workbench is opened. 

Setting level cost to -1 is not a pretty solution, but it is the one that works 100% as resulting cost will always be 0.