### PR TITLE
Fixes issue with experience when changing objective

### DIFF
--- a/src/main/java/xyz/iwolfking/scalingbingoseals/mixin/MixinApplySealRecipe.java
+++ b/src/main/java/xyz/iwolfking/scalingbingoseals/mixin/MixinApplySealRecipe.java
@@ -4,25 +4,40 @@ import com.llamalad7.mixinextras.sugar.Local;
 import iskallia.vault.item.crystal.CrystalData;
 import iskallia.vault.item.crystal.recipe.AnvilContext;
 import iskallia.vault.item.crystal.recipe.SealAnvilRecipe;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.NameTagItem;
-import net.minecraftforge.event.AnvilUpdateEvent;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import xyz.iwolfking.scalingbingoseals.objective.ScalingBingoCrystalObjective;
+
+import xyz.iwolfking.scalingbingoseals.config.ScalingBingoSealsConfig;
+import xyz.iwolfking.scalingbingoseals.util.INamedObjective;
+
 
 @Mixin(value = SealAnvilRecipe.class, remap = false)
 public class MixinApplySealRecipe {
     @Inject(method = "onSimpleCraft", at = @At(value = "INVOKE", target = "Liskallia/vault/item/crystal/CrystalData;write(Lnet/minecraft/world/item/ItemStack;)Liskallia/vault/item/crystal/CrystalData;", shift = At.Shift.AFTER))
-    private void updateItemName(AnvilContext context, CallbackInfoReturnable<Boolean> cir, @Local(ordinal = 2) ItemStack output) {
-        CrystalData outputData = CrystalData.read(output);
-        if(outputData.getObjective() instanceof ScalingBingoCrystalObjective scalingBingoCrystalObjective) {
-            context.setName(scalingBingoCrystalObjective.getCrystalName());
-            context.setLevelCost(-1);
+    private void updateItemName(AnvilContext context, CallbackInfoReturnable<Boolean> cir, @Local(ordinal = 0) ItemStack primary, @Local(ordinal = 2) ItemStack output) {
+        // Do nothing if name change is disabled
+        if (!ScalingBingoSealsConfig.COMMON.shouldChangeCrystalName.get())
+        {
+            return;
         }
+
+        CrystalData inputData = CrystalData.read(primary);
+        CrystalData outputData = CrystalData.read(output);
+
+        if (((INamedObjective) inputData.getObjective()).getCrystalName().
+            equals(((INamedObjective) outputData.getObjective()).getCrystalName()))
+        {
+            // Name change is not required.
+            return;
+        }
+
+        // Set name based on objective
+        context.setName(((INamedObjective) outputData.getObjective()).getCrystalName());
+        // Name change in anvil cost 1 level.
+        context.setLevelCost(-1);
     }
 }

--- a/src/main/java/xyz/iwolfking/scalingbingoseals/mixin/MixinCrystalObjective.java
+++ b/src/main/java/xyz/iwolfking/scalingbingoseals/mixin/MixinCrystalObjective.java
@@ -1,0 +1,45 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.scalingbingoseals.mixin;
+
+
+import org.spongepowered.asm.mixin.Intrinsic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import iskallia.vault.item.crystal.CrystalData;
+import iskallia.vault.item.crystal.objective.CrystalObjective;
+import xyz.iwolfking.scalingbingoseals.util.INamedObjective;
+
+
+/**
+ * This mixin adds default name for crystal objectives.
+ */
+@Mixin(value = CrystalObjective.class, remap = false)
+public abstract class MixinCrystalObjective implements INamedObjective
+{
+    @Intrinsic
+    @Override
+    public String getCrystalName()
+    {
+        String type = CrystalData.OBJECTIVE.getType((CrystalObjective) (Object) this);
+        return scalingbingoseals$getVaultObjective(type);
+    }
+
+
+    @Unique
+    public String scalingbingoseals$getVaultObjective(String key)
+    {
+        return switch (key == null ? "" : key.toLowerCase())
+        {
+            case "boss" -> "Guardians Crystal";
+            case "monolith" -> "Brazier Crystal";
+            case "empty", "", "pool", "null", "compound" -> "Vault Crystal";
+            default -> key.substring(0, 1).toUpperCase() + key.substring(1) + " Crystal";
+        };
+    }
+}

--- a/src/main/java/xyz/iwolfking/scalingbingoseals/util/INamedObjective.java
+++ b/src/main/java/xyz/iwolfking/scalingbingoseals/util/INamedObjective.java
@@ -1,0 +1,21 @@
+//
+// Created by BONNe
+// Copyright - 2025
+//
+
+
+package xyz.iwolfking.scalingbingoseals.util;
+
+
+/**
+ * This interface is used on all objectives to allow name changing in them.
+ */
+public interface INamedObjective
+{
+    /**
+     * Default name for `unknown` objectives will be Vault Crystal name.
+     *
+     * @return The crystal objective name.
+     */
+    String getCrystalName();
+}

--- a/src/main/resources/scalingbingoseals.mixins.json
+++ b/src/main/resources/scalingbingoseals.mixins.json
@@ -2,11 +2,12 @@
   "required": true,
   "minVersion": "0.8",
   "package": "xyz.iwolfking.scalingbingoseals.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "refmap": "scalingbingoseals.refmap.json",
   "mixins": [
     "MixinApplySealRecipe",
     "MixinClassicListenersLogic",
+    "MixinCrystalObjective",
     "MixinVaultCrystalConfig",
     "accessors.BingoTaskConfigAccessor"
   ],


### PR DESCRIPTION
- Added missing `shouldChangeCrystalName` config option.
- Apply name change and cost reduction only on name change
- Addd default names to all objectives.